### PR TITLE
Add support for LoongArch64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub fn arch() -> &'static str {
     "avr",
     "hexagon",
     "le32",
+    "loongarch64",
     "mips",
     "mips64",
     "msp430",


### PR DESCRIPTION
Add support for [LoongArch64](https://doc.rust-lang.org/rustc/platform-support/loongarch-linux.html) (A tier-2 with host tools target).