### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name        = "target"
-version     = "2.1.0"
+name = "target"
+version = "2.1.0"
 description = "Get information on compilation target"
-authors     = ["Casey Rodarmor <casey@rodarmor.com>"]
-license     = "CC0-1.0"
-repository    = "https://github.com/casey/target"
+authors = ["Casey Rodarmor <casey@rodarmor.com>"]
+license = "CC0-1.0"
+repository = "https://github.com/casey/target"
 
 [dev-dependencies]
 executable-path = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version     = "2.1.0"
 description = "Get information on compilation target"
 authors     = ["Casey Rodarmor <casey@rodarmor.com>"]
 license     = "CC0-1.0"
-homepage    = "https://github.com/casey/target"
+repository    = "https://github.com/casey/target"
 
 [dev-dependencies]
 executable-path = "1.0.0"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.